### PR TITLE
mount error(13): Permission denied

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Run client in a loop:
 ```
 while true; do
     date
-    docker run -it --rm --name client-smb --cap-add=SYS_ADMIN --cap-add DAC_READ_SEARCH --link samba:samba client-smb:1
+    docker run -it --rm --name client-smb --cap-add=SYS_ADMIN --cap-add DAC_READ_SEARCH --security-opt apparmor:unconfined --link samba:samba client-smb:1
     date
     sleep 1
 done


### PR DESCRIPTION
On Linux systems [with AppArmor](moby/moby#16429 (comment)) the script fails to mount with _Permission Denied_. Disabling it [solves the issue](moby/moby#16429 (comment))